### PR TITLE
refactor ProgressScreen to consume aggregated data from backend

### DIFF
--- a/src/components/VictoryStackedBarChart.tsx
+++ b/src/components/VictoryStackedBarChart.tsx
@@ -4,18 +4,16 @@ import { CartesianChart, StackedBar } from 'victory-native';
 import { useFont } from '@shopify/react-native-skia';
 
 type MacroData = {
-  day: number; // 1 (Mon) to 7 (Sun) for week view
+  day: number; // 1 (Mon) to 7 (Sun) for week view, or sequential for other periods
   protein: number;
   carbs: number;
   fat: number;
   calories: number;
   date: string;
+  period_label: string;
 };
 
 type TimePeriod = '1w' | '1m' | '3m' | '6m' | '1y';
-
-// Day labels for week view
-const dayLabels = ['Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun'];
 
 const macroColors = ['#7E54D9', '#FFC008', '#E283E0', '#ffffff']; // [protein, carbs, fat, calories]
 
@@ -132,78 +130,22 @@ export const VictoryStackedBarChart = ({
   const screenWidth = Dimensions.get('window').width;
   const padding = 10;
 
-  // Transform data based on time period
+  // Transform data for the chart - use period_label from backend
   const getChartData = () => {
-    if (timePeriod === '1w') {
-      // Week view: show days
-      // Create a complete week array with all 7 days
-      const weekData = Array.from({ length: 7 }, (_, index) => {
-        // Find data for this day of the week (1-7)
-        const dayData = data.find(d => d.day === index + 1);
-        
-        if (dayData) {
-          const calorieMacros = convertMacrosToCalories(dayData.protein, dayData.carbs, dayData.fat);
-          return {
-            x: dayLabels[index],
-            protein: calorieMacros.protein,
-            carbs: calorieMacros.carbs,
-            fat: calorieMacros.fat,
-            calories: dayData.calories,
-            originalProtein: dayData.protein,
-            originalCarbs: dayData.carbs,
-            originalFat: dayData.fat,
-            date: dayData.date
-          };
-        } else {
-          // Return zero data for missing days
-          return {
-            x: dayLabels[index],
-            protein: 0,
-            carbs: 0,
-            fat: 0,
-            calories: 0,
-            originalProtein: 0,
-            originalCarbs: 0,
-            originalFat: 0,
-            date: ''
-          };
-        }
-      });
-      
-      console.log('Week data with calorie values:', weekData.map(d => ({
-        day: d.x,
-        protein: d.protein,
-        carbs: d.carbs,
-        fat: d.fat,
-        calories: d.calories
-      })));
-      return weekData;
-    } else {
-      // Month/Quarter/Year view: show weeks or months
-      const groupedData = groupDataByPeriod(data, timePeriod);
-      const chartData = groupedData.map((group, index) => {
-        const calorieMacros = convertMacrosToCalories(group.protein, group.carbs, group.fat);
-        return {
-          x: getXAxisLabel(group.period, timePeriod),
-          protein: calorieMacros.protein,
-          carbs: calorieMacros.carbs,
-          fat: calorieMacros.fat,
-          calories: group.calories,
-          originalProtein: group.protein,
-          originalCarbs: group.carbs,
-          originalFat: group.fat,
-          period: group.period
-        };
-      });
-      console.log('Grouped data with calorie values:', chartData.map(d => ({
-        period: d.x,
-        protein: d.protein,
-        carbs: d.carbs,
-        fat: d.fat,
-        calories: d.calories
-      })));
-      return chartData;
-    }
+    return data.map((item, index) => {
+      const calorieMacros = convertMacrosToCalories(item.protein, item.carbs, item.fat);
+      return {
+        x: item.period_label, // Use the period_label from backend
+        protein: calorieMacros.protein,
+        carbs: calorieMacros.carbs,
+        fat: calorieMacros.fat,
+        calories: item.calories,
+        originalProtein: item.protein,
+        originalCarbs: item.carbs,
+        originalFat: item.fat,
+        date: item.date
+      };
+    });
   };
 
   const chartData = getChartData() as Array<{
@@ -216,32 +158,18 @@ export const VictoryStackedBarChart = ({
     originalCarbs: number;
     originalFat: number;
     date?: string;
-    period?: string;
   }>;
 
   // Calculate domain for y-axis - map to the highest value
   let maxValue = 0;
   
-  if (timePeriod === '1w') {
-    // For week view, use individual day data
-    maxValue = Math.max(
-      ...data.map(d => {
-        const calorieMacros = convertMacrosToCalories(d.protein, d.carbs, d.fat);
-        const macroSum = calorieMacros.protein + calorieMacros.carbs + calorieMacros.fat;
-        return Math.max(macroSum, d.calories);
-      })
-    );
-  } else {
-    // For month/quarter/year view, use grouped data
-    const groupedData = groupDataByPeriod(data, timePeriod);
-    maxValue = Math.max(
-      ...groupedData.map(group => {
-        const calorieMacros = convertMacrosToCalories(group.protein, group.carbs, group.fat);
-        const macroSum = calorieMacros.protein + calorieMacros.carbs + calorieMacros.fat;
-        return Math.max(macroSum, group.calories);
-      })
-    );
-  }
+  maxValue = Math.max(
+    ...data.map(d => {
+      const calorieMacros = convertMacrosToCalories(d.protein, d.carbs, d.fat);
+      const macroSum = calorieMacros.protein + calorieMacros.carbs + calorieMacros.fat;
+      return Math.max(macroSum, d.calories);
+    })
+  );
   
   // Round up to nearest nice number for y-axis
   const yDomain: [number, number] = [0, Math.ceil(maxValue / 500) * 500];
@@ -253,9 +181,7 @@ export const VictoryStackedBarChart = ({
   const handleBarPress = (index: number) => {
     const dataPoint = chartData[index];
     if (dataPoint) {
-      const periodLabel = timePeriod === '1w' && 'date' in dataPoint 
-        ? `${dataPoint.x} (${dataPoint.date})` 
-        : dataPoint.x;
+      const periodLabel = dataPoint.x;
       
       setTooltipData({
         period: periodLabel,
@@ -341,125 +267,6 @@ export const VictoryStackedBarChart = ({
       />
     </View>
   );
-};
-
-// Helper function to group data by time period
-const groupDataByPeriod = (data: MacroData[], timePeriod: TimePeriod) => {
-  const groups: { [key: string]: { protein: number; carbs: number; fat: number; calories: number; period: string } } = {};
-
-  // Get the current date and calculate the start date based on time period
-  const now = new Date();
-  let startDate: Date;
-
-  switch (timePeriod) {
-    case '1m':
-      startDate = new Date(now.getFullYear(), now.getMonth(), 1); // Start of current month
-      break;
-    case '3m':
-      startDate = new Date(now.getFullYear(), now.getMonth() - 2, 1); // 3 months ago
-      break;
-    case '6m':
-      startDate = new Date(now.getFullYear(), now.getMonth() - 5, 1); // 6 months ago
-      break;
-    case '1y':
-      startDate = new Date(now.getFullYear() - 1, now.getMonth(), 1); // 1 year ago
-      break;
-    default:
-      startDate = new Date(0); // All data
-  }
-
-  // Initialize all expected periods for 1m view
-  if (timePeriod === '1m') {
-    // Initialize all 4-5 weeks of the month
-    for (let week = 1; week <= 5; week++) {
-      const periodKey = `W${week}`;
-      groups[periodKey] = { protein: 0, carbs: 0, fat: 0, calories: 0, period: periodKey };
-    }
-  }
-
-  data.forEach(item => {
-    const date = new Date(item.date);
-    
-    // Skip data outside the time period
-    if (date < startDate) {
-      return;
-    }
-
-    let periodKey: string;
-
-    switch (timePeriod) {
-      case '1m':
-        // Group by week (W1, W2, W3, W4, W5)
-        const weekOfMonth = Math.ceil(date.getDate() / 7);
-        periodKey = `W${weekOfMonth}`;
-        break;
-      case '3m':
-      case '6m':
-        // Group by month (Jan, Feb, Mar, etc.)
-        periodKey = date.toLocaleDateString('en-US', { month: 'short' });
-        break;
-      case '1y':
-        // Group by quarter (Q1, Q2, Q3, Q4)
-        const quarter = Math.ceil((date.getMonth() + 1) / 3);
-        periodKey = `Q${quarter}`;
-        break;
-      default:
-        periodKey = item.date;
-    }
-
-    if (!groups[periodKey]) {
-      groups[periodKey] = { protein: 0, carbs: 0, fat: 0, calories: 0, period: periodKey };
-    }
-
-    groups[periodKey].protein += item.protein;
-    groups[periodKey].carbs += item.carbs;
-    groups[periodKey].fat += item.fat;
-    groups[periodKey].calories += item.calories;
-  });
-
-  // Sort the groups by date for proper ordering
-  const sortedGroups = Object.values(groups).sort((a, b) => {
-    if (timePeriod === '1m') {
-      // For weeks, sort by week number
-      const weekA = parseInt(a.period.replace('W', ''));
-      const weekB = parseInt(b.period.replace('W', ''));
-      return weekA - weekB;
-    } else if (timePeriod === '3m' || timePeriod === '6m') {
-      // For months, sort by month order
-      const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-      const monthA = months.indexOf(a.period);
-      const monthB = months.indexOf(b.period);
-      return monthA - monthB;
-    } else if (timePeriod === '1y') {
-      // For quarters, sort by quarter number
-      const quarterA = parseInt(a.period.replace('Q', ''));
-      const quarterB = parseInt(b.period.replace('Q', ''));
-      return quarterA - quarterB;
-    }
-    return 0;
-  });
-
-  return sortedGroups;
-};
-
-// Helper function to get x-axis labels
-const getXAxisLabel = (period: string, timePeriod: TimePeriod) => {
-  
-  if (!period) {
-    return 'Unknown';
-  }
-  
-  switch (timePeriod) {
-    case '1m':
-      return period; // W1, W2, W3, W4
-    case '3m':
-    case '6m':
-      return period; // Jan, Feb, Mar, etc.
-    case '1y':
-      return period; // Q1, Q2, Q3, Q4
-    default:
-      return period;
-  }
 };
 
 export default VictoryStackedBarChart; 

--- a/src/screens/ProgressScreen.tsx
+++ b/src/screens/ProgressScreen.tsx
@@ -37,6 +37,7 @@ interface MacroBarData {
   fat: number;
   calories: number;
   date: string;
+  period_label: string;
 }
 
 const ProgressScreen = () => {
@@ -61,32 +62,18 @@ const ProgressScreen = () => {
   let hasNonZeroData = false;
   
   try {
-    if (data && Array.isArray(data.daily_macros) && data.daily_macros.length > 0) {
-      // Filter out future dates
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
-
-      macroBarData = data.daily_macros
-        .filter(dayData => {
-          const date = new Date(dayData.date);
-          date.setHours(0, 0, 0, 0);
-          return date <= today;
-        })
-        .map(dayData => {
-          const date = new Date(dayData.date);
-          // Convert to Monday = 1, Tuesday = 2, etc. for the chart
-          const dayOfWeek = date.getDay(); // 0 = Sunday, 1 = Monday, etc.
-          const adjustedDay = dayOfWeek === 0 ? 7 : dayOfWeek; // Monday = 1, Sunday = 7
-          return {
-            day: adjustedDay, // Already in 1-7 range for the chart
-            protein: Number(dayData.protein) || 0,
-            carbs: Number(dayData.carbs) || 0,
-            fat: Number(dayData.fat) || 0,
-            calories: Number(dayData.calories) || 0,
-            date: dayData.date,
-          };
-        })
-        .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    if (data && Array.isArray(data.period_macros) && data.period_macros.length > 0) {
+      macroBarData = data.period_macros.map((periodData, index) => {
+        return {
+          day: index + 1, // Use index + 1 for chart positioning
+          protein: Number(periodData.protein) || 0,
+          carbs: Number(periodData.carbs) || 0,
+          fat: Number(periodData.fat) || 0,
+          calories: Number(periodData.calories) || 0,
+          date: periodData.date,
+          period_label: periodData.period_label,
+        };
+      });
 
       // Check if we have any non-zero values
       hasNonZeroData = macroBarData.some(day => 
@@ -96,6 +83,7 @@ const ProgressScreen = () => {
       // Debug logging
       console.log('ProgressScreen: Processed macroBarData:', macroBarData.map(d => ({
         date: d.date,
+        period_label: d.period_label,
         day: d.day,
         protein: d.protein,
         carbs: d.carbs,

--- a/src/services/mealService.ts
+++ b/src/services/mealService.ts
@@ -68,37 +68,40 @@ interface DailyProgressResponse {
 }
 
 interface MealProgressResponse {
-    daily_macros: [
-        {
-                date: string,
-            calories: number,
-            protein: number;
-            carbs: number;
-            fat: number;
-        }
-    ];
-    average_macros: {
-        calories: number,
-        protein: number,
-        carbs: number,
-        fat: number
-    };
-    target_macros: {
-        calories: number,
-        protein: number,
-        carbs: number,
-        fat: number
-    };
-    comparison_percentage: {
-        calories: number,
-        protein: number,
-        carbs: number,
-        fat: number
-    };
-    start_date: string;
-    end_date: string;
-    days_with_logs: number;
-    total_days: number;
+  period_macros: [
+    {
+      period_label: string;
+      date: string,
+      calories: number,
+      protein: number;
+      carbs: number;
+      fat: number;
+    }
+  ];
+  average_macros: {
+    calories: number,
+    protein: number,
+    carbs: number,
+    fat: number
+  };
+  target_macros: {
+    calories: number,
+    protein: number,
+    carbs: number,
+    fat: number
+  };
+  comparison_percentage: {
+    calories: number,
+    protein: number,
+    carbs: number,
+    fat: number
+  };
+  start_date: string;
+  end_date: string;
+  period_type: string;
+  aggregation_period: string;
+  days_with_logs: number;
+  total_days: number;
 }
 
 /**

--- a/src/store/useProgressStore.ts
+++ b/src/store/useProgressStore.ts
@@ -1,7 +1,8 @@
 import { getMealProgress, getMealByPeriod } from "src/services/mealService";
 import { create } from "zustand";
 
-type MacroDay = {
+type MacroPeriod = {
+  period_label: string;
   date: string;
   protein: number;
   carbs: number;
@@ -10,11 +11,16 @@ type MacroDay = {
 };
 
 type MacrosData = {
-  daily_macros: MacroDay[];
+  period_macros: MacroPeriod[];
   average_macros: { calories: number; protein: number; carbs: number; fat: number };
   target_macros: { calories: number; protein: number; carbs: number; fat: number };
+  comparison_percentage: { calories: number; protein: number; carbs: number; fat: number };
   start_date: string;
   end_date: string;
+  period_type: string;
+  aggregation_period: string;
+  days_with_logs: number;
+  total_days: number;
 };
 
 type ProgressState = {


### PR DESCRIPTION
The progress data was been aggregated from the frontend before rendered on the chart leading to slow rendering of the chart. This was moved to the backend and the Aggregated data is rendered directly making the chart render faster.