### PR TITLE
fix: resolve issue where logging meals manually from favourites returns an error.

### DIFF
--- a/src/screens/AddMealScreen.tsx
+++ b/src/screens/AddMealScreen.tsx
@@ -179,10 +179,11 @@ export const AddMealScreen: React.FC = () => {
         setCalories(meal.macros.calories.toString());
         setProtein(meal.macros.protein.toString());
         setCarbs(meal.macros.carbs.toString());
-        setNoOfServings(meal.no_of_servings.toString());
+        setNoOfServings(meal?.no_of_servings?.toString() || '1');
         setFats(meal.macros.fat.toString());
-        setLoggingMode('favorite');
+        setLoggingMode(meal.logging_mode || 'manual');
         setMealType(meal.meal_type);
+
     };
 
     /**

--- a/src/services/favoritesService.ts
+++ b/src/services/favoritesService.ts
@@ -15,10 +15,13 @@ export interface FavoriteMeal {
     location: string;
   };
   addedAt: string;
+  amount: number;
   serving_size: number;
+  serving_unit: string;
   no_of_servings: number;
   meal_type: string;
   meal_time: string;
+  logging_mode: string;
 }
 
 const FAVORITES_STORAGE_KEY = '@macro_meals_favorites';


### PR DESCRIPTION
The issue was as a result of "favourite" being passed as logging_mode instead of "manual". Passing "maual" to the logging mode fixed the issue.